### PR TITLE
Add Compass component config (compass.yml)

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -1,0 +1,8 @@
+name: slack_een
+id: ari:cloud:compass:4337fc0d-aa55-4ff9-bd75-ef7117ff9381:component/4c6fdffe-fa4a-46ef-9e6f-a1aa05480c89/e7efc56c-0e5c-4028-aa52-8c3b9f930444
+configVersion: 1
+typeId: OTHER
+ownerId: ari:cloud:identity::team/02623aed-f05b-4acd-8187-7932552722de-32 # Edge Infra (200)
+links:
+  - type: REPOSITORY
+    url: https://github.com/EENCloud/slack_een


### PR DESCRIPTION
Onboards `slack_een` to Compass (replaces the stale compass-github-importer PR).

- typeId: `OTHER`
- owner: Edge Infra (200)
- component: `e7efc56c-0e5c-4028-aa52-8c3b9f930444`