### PR TITLE
CODEOWNERS: owning team Edge Infra (200)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS — default owner is the repository's owning team.
+# Managed by EngOps (scripts/sync-codeowners.js). Team: Edge Infra (200).
+* @EENCloud/edge-infra-200


### PR DESCRIPTION
Ensures **slack_een** has a CODEOWNERS file naming its owning team **Edge Infra (200)** (`@EENCloud/edge-infra-200`).

**Changes:** create .github/CODEOWNERS (@EENCloud/edge-infra-200)

_Opened by `scripts/sync-codeowners.js` (EngOps). The owning team comes from `truths/repositories.json` → `truths/teams.json`._
